### PR TITLE
ci: split Xyce conformance from fast tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,21 @@ jobs:
       - name: Clear check artifacts before tests
         run: cargo clean
       - name: Test core integration tests (fast tier)
-        # Skip only the vendored conformance suites (their test names start
-        # with test_ngspice_ / test_full_ngspice). A bare "ngspice" filter
-        # used to swallow seven oracle-pinned tests in unrelated files whose
-        # names merely mention ngspice.
+        # Keep the vendored ngspice and Xyce corpus sweeps out of the PR
+        # gate. Their exact name prefixes avoid skipping oracle-pinned tests
+        # in unrelated files that merely mention either simulator.
         run: >-
           cargo test --locked -p rspice-core --tests
           -- --skip test_ngspice_ --skip test_full_ngspice
+          --skip test_xyce_ --skip test_full_xyce
+      - name: Xyce compatibility smoke
+        # The full 4,055-deck Xyce corpus runs serially in nightly CI. These
+        # small oracle-backed checks retain DC, transient, and wrapper coverage
+        # in the per-commit gate.
+        run: |
+          cargo test --locked -p rspice-core --test xyce_regression test_xyce_abm_math_function_cases_run -- --exact --test-threads=1
+          cargo test --locked -p rspice-core --test xyce_regression test_xyce_static_capacitor_transient_case_runs -- --exact --test-threads=1
+          cargo test --locked -p rspice-core --test xyce_regression test_xyce_absolute_include_library_wrapper_cases_run_natively -- --exact --test-threads=1
       - name: Core library unit tests
         run: cargo test --locked -p rspice-core --lib
       - name: Clear core test artifacts

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,8 +34,16 @@ jobs:
         run: >-
           cargo test --locked --workspace --exclude rspice-python --exclude rspice-wasm
           --release -- --skip test_ngspice_ --skip test_full_ngspice
+          --skip test_xyce_ --skip test_full_xyce
       - name: Core library unit tests (release)
         run: cargo test --locked -p rspice-core --lib --release
+      - name: Xyce conformance suite
+        # Every Xyce regression test takes the shared runner mutex. Running
+        # the target serially avoids misleading long-running queued tests and
+        # executes the complete corpus once per nightly run.
+        run: >-
+          cargo test --locked -p rspice-core --release --test xyce_regression
+          -- --nocapture --test-threads=1
       - name: ngspice conformance report
         # Serial test threads: each deck spawns a case-runner subprocess with
         # a hard per-case timeout; parallel threads oversubscribe the runner

--- a/tools/ci/test_ci_configuration.py
+++ b/tools/ci/test_ci_configuration.py
@@ -134,6 +134,20 @@ class CiConfigurationTests(unittest.TestCase):
         )
         self.assertIn("Test core integration tests (fast tier)", workflow)
         self.assertIn("cargo test --locked -p rspice-core --tests", workflow)
+        self.assertIn("--skip test_xyce_ --skip test_full_xyce", workflow)
+        self.assertIn("Xyce compatibility smoke", workflow)
+        self.assertIn(
+            "cargo test --locked -p rspice-core --test xyce_regression test_xyce_abm_math_function_cases_run -- --exact --test-threads=1",
+            workflow,
+        )
+        self.assertIn(
+            "cargo test --locked -p rspice-core --test xyce_regression test_xyce_static_capacitor_transient_case_runs -- --exact --test-threads=1",
+            workflow,
+        )
+        self.assertIn(
+            "cargo test --locked -p rspice-core --test xyce_regression test_xyce_absolute_include_library_wrapper_cases_run_natively -- --exact --test-threads=1",
+            workflow,
+        )
         self.assertIn("Test non-UI crates (fast tier)", workflow)
         self.assertIn("cargo test --locked -p rspice-cli -p rspice-veriloga -p rspice-bench", workflow)
         self.assertIn("Test Verilog-A native JIT units (Linux x64)", workflow)
@@ -179,6 +193,13 @@ class CiConfigurationTests(unittest.TestCase):
 
         self.assertIn("cargo test --locked -p rspice-core --lib", ci_workflow)
         self.assertIn("cargo test --locked -p rspice-core --lib --release", nightly_workflow)
+        self.assertIn("--skip test_xyce_ --skip test_full_xyce", nightly_workflow)
+        self.assertIn("Xyce conformance suite", nightly_workflow)
+        self.assertIn(
+            "cargo test --locked -p rspice-core --release --test xyce_regression\n"
+            "          -- --nocapture --test-threads=1",
+            nightly_workflow,
+        )
 
     def test_linux_ci_runs_clippy_warning_clean(self) -> None:
         workflow = read_text(".github/workflows/ci.yml")


### PR DESCRIPTION
## Summary

- keep five oracle-backed Xyce DC, transient, and wrapper checks in per-commit CI
- move the complete Xyce regression target to the nightly release job, run serially
- lock the workflow layout in the CI configuration test

## Why

The fast integration step ran the complete Xyce corpus even though its runner serializes all Xyce tests behind a shared mutex. This made PR CI appear stalled and duplicated the broad conformance responsibility better suited to nightly validation.

## Validation

- `py -3 tools/ci/test_ci_configuration.py`
- three selected `xyce_regression` smoke tests (ABM math, capacitor transient, absolute include/library wrapper)