### PR TITLE
Allow shared Cargo target for web releases

### DIFF
--- a/tools/deploy/build_site.py
+++ b/tools/deploy/build_site.py
@@ -671,7 +671,10 @@ def main():
 
     root = Path(capture(["git", "rev-parse", "--show-toplevel"]))
     os.chdir(root)
-    target = Path("target/wasm32-unknown-unknown/release")
+    target_root = Path(os.environ.get("CARGO_TARGET_DIR", root / "target"))
+    if not target_root.is_absolute():
+        target_root = root / target_root
+    target = target_root / "wasm32-unknown-unknown" / "release"
     site_source = Path(args.site_source).resolve()
     validate_site_source(site_source)
     out = validated_output_path(root, site_source, args.out)


### PR DESCRIPTION
﻿## What changed

Allow the browser release assembler to honor `CARGO_TARGET_DIR` when locating built WebAssembly artifacts.

## Why

The local, CI-independent site publisher builds from clean temporary worktrees while reusing the established Cargo cache on Windows. Cargo already honors this variable; the assembler now reads outputs from the same configured directory.

## Validation

- `py -3 -m unittest tools.deploy.test_build_site -v` (19 passed)
- `git diff --check -- tools/deploy/build_site.py`
