### PR TITLE
ci: isolate BUG907 hosted validation

### DIFF
--- a/.github/workflows/bug907-hosted-validation.yml
+++ b/.github/workflows/bug907-hosted-validation.yml
@@ -14,6 +14,7 @@ env:
   CARGO_INCREMENTAL: "0"
   RUST_BACKTRACE: "1"
   RUST_TOOLCHAIN: "1.94.0"
+  RSPICE_XYCE_HARD_CASE_TIMEOUT_MS: "180000"
 
 jobs:
   full-xyce-release:

--- a/.github/workflows/bug907-hosted-validation.yml
+++ b/.github/workflows/bug907-hosted-validation.yml
@@ -1,0 +1,35 @@
+name: BUG907 hosted validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/bug907-hosted-validation.yml
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  RUST_BACKTRACE: "1"
+  RUST_TOOLCHAIN: "1.94.0"
+
+jobs:
+  full-xyce-release:
+    name: Full Xyce corpus (Linux, release)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Rust toolchain
+        run: rustup toolchain install ${{ env.RUST_TOOLCHAIN }} --profile minimal
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: bug907-hosted-validation
+      - name: Authoritative Xyce aggregate
+        run: >-
+          cargo test --locked --release -p rspice-conformance
+          --test xyce_regression
+          test_full_xyce_suite_summary_accounts_for_every_deck
+          -- --exact --nocapture


### PR DESCRIPTION
Temporary validation-only PR. Runs the unchanged release Xyce aggregate because the inherited Nightly workspace pre-step is red and Windows Smart App Control blocks the newly linked local release test binary. This PR will be closed and its branch removed after the result.